### PR TITLE
Fixed typos in QUICKSTART.md

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -121,11 +121,11 @@ If NIC used for management (ex: ssh) was selected, you will lose connection.
 
 Unbound NICs from ixgbe driver.
 
-	$ sudo ${RTE_SDK}/pci_unbind.py -b igb_uio 0000:02:02.0 0000:02:03.0 0000:02:04.0
+	$ sudo ${RTE_SDK}/tools/pci_unbind.py -b igb_uio 0000:02:02.0 0000:02:03.0 0000:02:04.0
 
 Check the current status of NICs whehter the 2nd, 3rd and 4th interface is registerd with igb_uio driver
 
-	$ sudo ${RTE_SDK}/pci_unbind.py --status
+	$ sudo ${RTE_SDK}/tools/pci_unbind.py --status
 
 	Network devices using IGB_UIO driver
 	====================================


### PR DESCRIPTION
I've found out trivial typos in QUICKSTART.md.
Please check the line 104, 124, and 128.

```
104     $ sudo ${RTE_SDK}/tools/pci_unbind.py --status

124     $ sudo ${RTE_SDK}/pci_unbind.py -b igb_uio 0000:02:02.0 0000:02:03.0 0000:02:04.0

128     $ sudo ${RTE_SDK}/pci_unbind.py --status
```

Since "pci_unbind.py" is located in the ${RTE_SDK}/tools/, the line 124 and 128 should be fixed.
