### PR TITLE
Configure port without hardware offload option in case of virtio-net.

### DIFF
--- a/src/dataplane/dpdk/dpdk_io.c
+++ b/src/dataplane/dpdk/dpdk_io.c
@@ -933,6 +933,7 @@ app_init_nics(void) {
   uint8_t port, queue;
   int ret;
   uint32_t n_rx_queues, n_tx_queues;
+  struct rte_eth_dev_info dev_info;
 
 #ifndef RTE_VERSION_NUM
   /* Init driver */
@@ -968,6 +969,15 @@ app_init_nics(void) {
       rte_panic("Cannot init NIC port %u (%s)\n",
                 (unsigned) port, strerror(-ret));
     }
+
+    rte_eth_dev_info_get(port, &dev_info);
+    if (strcmp(dev_info.driver_name, "rte_virtio_pmd") == 0) {
+      /* Virtio does not support hw offload */
+      tx_conf.txq_flags = ETH_TXQ_FLAGS_NOOFFLOADS;
+    } else {
+      tx_conf.txq_flags = 0;
+    }
+
     rte_eth_promiscuous_enable(port);
 
     /* Init RX queues */


### PR DESCRIPTION
Currently rte_eth_tx_queue_setup() trying configure queue with hardware
offload option as default. lagopus failed to configure virtio tx queue at
rte_eth_tx_queue_setup(), because virtio does not support hardware offload
and virtio assumes given port supports hardware offload feature.
This fix adds ETH_TXQ_FLAGS_NOOFFLOADS option to rte_eth_tx_queue_setup()'s
arguments of virtio configuration explicitly.