### PR TITLE
Edit introduction for online documentation when you build fail for absence of unity

### DIFF
--- a/configure
+++ b/configure
@@ -18093,7 +18093,8 @@ fi
 $as_echo "unity is available." >&6; }
   else
     HAVE_UNITY=
-    as_fn_error $? "Unity is not available. developer's build requires Unity." "$LINENO" 5
+    as_fn_error $? "Unity is not available. developer's build requires Unity. Please check https://github.com/lagopus/lagopus/blob/master/docs/how-to-write-tests-in-lagopus.md." "$LINENO" 5
+
   fi
 
   # Extract the first word of "gcovr", so it can be a program name with args.

--- a/configure.ac
+++ b/configure.ac
@@ -484,7 +484,8 @@ if test "X${developer}" != "Xno"; then
     AC_MSG_RESULT([unity is available.])
   else
     HAVE_UNITY=
-    AC_MSG_ERROR([Unity is not available. developer's build requires Unity.])
+    AC_MSG_ERROR([Unity is not available. developer's build requires Unity. Please check https://github.com/lagopus/lagopus/blob/master/docs/how-to-write-tests-in-lagopus.md.])
+
   fi
 
   AC_CHECK_PROG([HAVE_GCOVR], [gcovr], [yes],)


### PR DESCRIPTION
`Unity` is very confusing name.
So error message below

```
ruby: No such file or directory -- tools/unity/auto/generate_test_runner.rb (LoadError)
configure: error: Unity is not available. developer's build requires Unity.
```

is very ambiguous. We should announce correct documentation.