### PR TITLE
Configure port without hardware offload option in case of virtio-net (for lagopus-0.2 and master).

### DIFF
--- a/src/dataplane/dpdk/dpdk_io.c
+++ b/src/dataplane/dpdk/dpdk_io.c
@@ -1041,6 +1041,11 @@ dpdk_configure_interface(struct interface *ifp) {
               portid,
               ret);
   }
+
+  /* Virtio does not support hw offload */
+  if (strcmp(ifp->devinfo.driver_name, "rte_virtio_pmd") == 0) {
+    ifp->devinfo.default_txconf.txq_flags = ETH_TXQ_FLAGS_NOOFFLOADS;
+  }
   rte_eth_promiscuous_enable(portid);
 
   /* Init RX queues */


### PR DESCRIPTION
Currently rte_eth_tx_queue_setup() trying configure queue with hardware
offload option as default. lagopus failed to configure virtio tx queue at
rte_eth_tx_queue_setup(), because virtio does not support hardware offload
and virtio assumes given port supports hardware offload feature.
This fix adds ETH_TXQ_FLAGS_NOOFFLOADS option to rte_eth_tx_queue_setup()'s
arguments of virtio configuration explicitly.