### PR TITLE
Avoid to error-return when MTU change is not supported.

### DIFF
--- a/src/dataplane/dpdk/dpdk_io.c
+++ b/src/dataplane/dpdk/dpdk_io.c
@@ -1035,7 +1035,7 @@ dpdk_configure_interface(struct interface *ifp) {
               (unsigned) portid, strerror(-ret));
   }
   ret = rte_eth_dev_set_mtu(portid, ifp->info.eth_dpdk_phy.mtu);
-  if (ret < 0) {
+  if (ret < 0 && ret != -ENOTSUP) {
     rte_panic("Cannot set MTU(%d) for port %d (%d)\n",
               ifp->info.eth_dpdk_phy.mtu,
               portid,


### PR DESCRIPTION
In case of virtio-net, MTU change is not supported in DPDK SDK,
then rte_eth_dev_set_mtu() returns -ENOTSUP and it is expected.
This fix adds to pass error condition in case of -ENOTSUP.