### PR TITLE
Enable OF-compatible queue handling

### DIFF
--- a/mk/make_dpdk.sh
+++ b/mk/make_dpdk.sh
@@ -81,6 +81,7 @@ edit_dpdk_config CONFIG_RTE_LIBRTE_PMD_PCAP=n $NEWCONFIG
 edit_dpdk_config CONFIG_RTE_APP_TEST=n $NEWCONFIG
 edit_dpdk_config CONFIG_RTE_TEST_PMD=n $NEWCONFIG
 edit_dpdk_config CONFIG_RTE_IXGBE_INC_VECTOR=n $NEWCONFIG
+eidt_dpdk_config CONFIG_RTE_SCHED_COLLECT_STATS=y $NEWCONFIG
 
 ${MAKE} T=${NEW_TARGET} config && ${MAKE} && \
     RTE_SDK="${TOPDIR}/${DPDKDIR}" \

--- a/src/dataplane/dpdk/dpdk_io.c
+++ b/src/dataplane/dpdk/dpdk_io.c
@@ -483,6 +483,41 @@ app_lcore_io_rx_flush(struct app_lcore_params_io *lp, uint32_t n_workers) {
 }
 
 /**
+ * Move packets through the qos scheduler if any configured.
+ * Return the number of packets ready to be transmitted.
+ */
+static inline uint32_t
+schedule_tx_packets(struct interface *ifp, struct app_mbuf_array *outbufs) {
+  struct lagopus_packet *pkt;
+  struct rte_mbuf *mbuf;
+  uint32_t qidx, color;
+
+  if (ifp == NULL || ifp->sched_port == NULL) {
+    return outbufs->n_mbufs;
+  }
+
+  for (uint32_t i = 0; i < outbufs->n_mbufs; ++i) {
+    mbuf = outbufs->array[i];
+    pkt = (struct lagopus_packet*)(mbuf->buf_addr + APP_DEFAULT_MBUF_LOCALDATA_OFFSET);
+    qidx = (uint32_t)dpdk_interface_queue_id_to_index(ifp, pkt->queue_id);
+    color = rte_meter_trtcm_color_blind_check(&ifp->ifqueue.meters[qidx], rte_rdtsc(), OS_M_PKTLEN(mbuf));
+    rte_sched_port_pkt_write(mbuf, 0, 0, qidx, 0, color);
+  }
+
+  // TODO: rethink TX processing to enable appropriate scheduling.
+  //  Under a heavy load we should dequeue less packets than inserted:
+  //  otherwise we will just move low priority packets to the back of the burst
+  //  and will provide no advantage to high priority packets of the next burst.
+
+  rte_sched_port_enqueue(ifp->sched_port, outbufs->array, outbufs->n_mbufs);
+  outbufs->n_mbufs = (uint32_t)rte_sched_port_dequeue(
+     ifp->sched_port, outbufs->array, APP_MBUF_ARRAY_SIZE
+  );
+
+  return outbufs->n_mbufs;
+}
+
+/**
  * Dequeue mbufs from output queue and send to ethernet port.
  * This function is called from I/O (Output) thread.
  */
@@ -535,31 +570,11 @@ app_lcore_io_tx(struct app_lcore_params_io *lp,
         lp->tx.mbuf_out_flush[port] = 1;
         continue;
       }
-      ifp = dpdk_interface_lookup(port);
-      if (ifp != NULL && ifp->sched_port != NULL) {
-        struct lagopus_packet *pkt;
-        struct rte_mbuf *m;
-        int qidx, color;
 
-        for (i = 0; i < n_mbufs; i++) {
-          m = lp->tx.mbuf_out[port].array[i];
-          pkt = (struct lagopus_packet *)
-                (m->buf_addr + APP_DEFAULT_MBUF_LOCALDATA_OFFSET);
-          if (unlikely(pkt->queue_id != 0)) {
-            qidx = dpdk_interface_queue_id_to_index(ifp, pkt->queue_id);
-            color = rte_meter_trtcm_color_blind_check(&ifp->ifqueue.meters[qidx],
-                    rte_rdtsc(),
-                    OS_M_PKTLEN(m));
-            rte_sched_port_pkt_write(m, 0, 0, 0, qidx, color);
-          }
-        }
-        n_mbufs = rte_sched_port_enqueue(ifp->sched_port,
-                                         lp->tx.mbuf_out[port].array,
-                                         n_mbufs);
-        n_mbufs = rte_sched_port_dequeue(ifp->sched_port,
-                                         lp->tx.mbuf_out[port].array,
-                                         n_mbufs);
-      }
+      ifp = dpdk_interface_lookup(port);
+      lp->tx.mbuf_out[port].n_mbufs = n_mbufs;
+      n_mbufs = schedule_tx_packets(ifp, &lp->tx.mbuf_out[port]);
+
       DPRINTF("send %d pkts\n", n_mbufs);
       n_pkts = rte_eth_tx_burst(port,
                                 0,
@@ -601,7 +616,8 @@ app_lcore_io_tx_flush(struct app_lcore_params_io *lp, __UNUSED void *arg) {
   uint8_t portid, i;
 
   for (i = 0; i < lp->tx.n_nic_ports; i++) {
-    uint32_t n_pkts;
+    struct interface *ifp;
+    uint32_t n_mbufs, n_pkts;
 
     portid = lp->tx.nic_ports[i];
     if (likely((lp->tx.mbuf_out_flush[portid] == 0) ||
@@ -609,16 +625,20 @@ app_lcore_io_tx_flush(struct app_lcore_params_io *lp, __UNUSED void *arg) {
       continue;
     }
 
-    DPRINTF("flush: send %d pkts\n", lp->tx.mbuf_out[portid].n_mbufs);
+    ifp = dpdk_interface_lookup(portid);
+    n_mbufs = schedule_tx_packets(ifp, &lp->tx.mbuf_out[portid]);
+
+    DPRINTF("flush: send %d pkts\n", n_mbufs);
     n_pkts = rte_eth_tx_burst(portid,
                               0,
                               lp->tx.mbuf_out[portid].array,
-                              (uint16_t)lp->tx.mbuf_out[portid].n_mbufs);
+                              (uint16_t)n_mbufs);
+
     DPRINTF("flus: sent %d pkts\n", n_pkts);
 
-    if (unlikely(n_pkts < lp->tx.mbuf_out[portid].n_mbufs)) {
+    if (unlikely(n_pkts < n_mbufs)) {
       uint32_t k;
-      for (k = n_pkts; k < lp->tx.mbuf_out[portid].n_mbufs; k ++) {
+      for (k = n_pkts; k < n_mbufs; k ++) {
         struct rte_mbuf *pkt_to_free = lp->tx.mbuf_out[portid].array[k];
         rte_pktmbuf_free(pkt_to_free);
       }

--- a/src/dataplane/dpdk/queue.c
+++ b/src/dataplane/dpdk/queue.c
@@ -29,35 +29,50 @@ lagopus_result_t
 dpdk_interface_queue_add(struct interface *ifp, dp_queue_info_t *queue) {
   struct dp_ifqueue new_ifqueue;
   struct rte_meter_trtcm_params param;
-  int i;
+  struct rte_meter_trtcm *meter;
+
+  lagopus_result_t rv;
+  int rte_err;
 
   if (ifp->ifqueue.nqueue >= DP_MAX_QUEUES) {
     return LAGOPUS_RESULT_TOO_MANY_OBJECTS;
   }
-  for (i = 0; i < ifp->ifqueue.nqueue; i++) {
+  if (ifp->ifqueue.nqueue >= RTE_SCHED_TRAFFIC_CLASSES_PER_PIPE) {
+    return LAGOPUS_RESULT_TOO_MANY_OBJECTS;
+  }
+  for (int i = 0; i < ifp->ifqueue.nqueue; i++) {
     if (ifp->ifqueue.queues[i]->id == queue->id) {
       return LAGOPUS_RESULT_ALREADY_EXISTS;
     }
   }
+
   memcpy(&new_ifqueue, &ifp->ifqueue, sizeof(new_ifqueue));
-  new_ifqueue.queues[new_ifqueue.nqueue] = queue;
+  memset(&new_ifqueue.stats[new_ifqueue.nqueue], 0, sizeof(new_ifqueue.stats[0]));
+
   param.cir = queue->committed_information_rate;
   param.pir = queue->peak_information_rate;
   param.cbs = queue->committed_burst_size;
   param.pbs = queue->peak_burst_size;
-  rte_meter_trtcm_config(&new_ifqueue.meters[new_ifqueue.nqueue], &param);
+
+  meter = &new_ifqueue.meters[new_ifqueue.nqueue];
+  if ((rte_err = rte_meter_trtcm_config(meter, &param)) != 0) {
+    lagopus_msg_error("rte_meter_trtcm_config got error: %d\n", rte_err);
+    return LAGOPUS_RESULT_ANY_FAILURES;
+  }
+
+  new_ifqueue.queues[new_ifqueue.nqueue] = queue;
   new_ifqueue.nqueue++;
-  dpdk_queue_configure(ifp, &new_ifqueue);
+
+  rv = dpdk_queue_configure(ifp, &new_ifqueue);
+  if (rv != LAGOPUS_RESULT_OK) return rv;
+
   memcpy(&ifp->ifqueue, &new_ifqueue, sizeof(new_ifqueue));
   return LAGOPUS_RESULT_OK;
 }
 
 lagopus_result_t
 dpdk_interface_queue_delete(struct interface *ifp, uint32_t queue_id) {
-  struct dp_ifqueue new_ifqueue;
-  int i;
-
-  for (i = 0; i < ifp->ifqueue.nqueue; i++) {
+  for (int i = 0; i < ifp->ifqueue.nqueue; i++) {
     if (ifp->ifqueue.queues[i]->id == queue_id) {
       ifp->ifqueue.nqueue--;
       memcpy(&ifp->ifqueue.queues[i], &ifp->ifqueue.queues[i + 1],
@@ -69,53 +84,117 @@ dpdk_interface_queue_delete(struct interface *ifp, uint32_t queue_id) {
   return LAGOPUS_RESULT_NOT_FOUND;
 }
 
+// sort queues by their priorities in ascending order
+static void sort_by_ascending_priority(struct dp_ifqueue *ifqueue) {
+  int nqueue = ifqueue->nqueue;
+
+  struct rte_sched_queue_stats stat;
+  struct rte_meter_trtcm meter;
+  dp_queue_info_t *queue;
+
+  for(int i = 0; i < nqueue - 1; ++i) {
+    for(int j = i + 1; j < nqueue; ++j) {
+      if (ifqueue->queues[i]->priority > ifqueue->queues[j]->priority) {
+
+        memcpy(&queue, &ifqueue->queues[i], sizeof(queue));
+        memcpy(&ifqueue->queues[i], &ifqueue->queues[j], sizeof(queue));
+        memcpy(&ifqueue->queues[j], &queue, sizeof(queue));
+
+        memcpy(&meter, &ifqueue->meters[i], sizeof(meter));
+        memcpy(&ifqueue->meters[i], &ifqueue->meters[j], sizeof(meter));
+        memcpy(&ifqueue->meters[j], &meter, sizeof(meter));
+
+        memcpy(&stat, &ifqueue->stats[i], sizeof(stat));
+        memcpy(&ifqueue->stats[i], &ifqueue->stats[j], sizeof(stat));
+        memcpy(&ifqueue->stats[j], &stat, sizeof(stat));
+      }
+    }
+  }
+}
+
 lagopus_result_t
 dpdk_queue_configure(struct interface *ifp, struct dp_ifqueue *ifqueue) {
   struct rte_sched_port_params params;
   struct rte_sched_subport_params subport_params;
   struct rte_sched_pipe_params pipe_params;
-  struct rte_sched_port *old_sched, *new_sched;
+  struct rte_sched_port *new_sched;
+
+  uint32_t rate_sum, burst_sum;
   unsigned lcore;
-  int i;
+  int rte_err, i;
 
   if (ifqueue->nqueue == 0) {
     dpdk_queue_unconfigure(ifp);
     return LAGOPUS_RESULT_OK;
   }
+
   params.name = ifp->name;
   params.pipe_profiles = &pipe_params;
   app_get_lcore_for_nic_tx(ifp->info.eth_dpdk_phy.port_number, &lcore);
   params.socket = rte_lcore_to_socket_id(lcore);
   params.mtu = ifp->info.eth_dpdk_phy.mtu;
   params.frame_overhead = 12; /* minimum */
+
   params.n_subports_per_port = 1;
   params.n_pipes_per_subport = 1;
-  params.rate = 0;
-  subport_params.tc_period = 100;
-  subport_params.tb_rate = 0;
-  subport_params.tb_size = 0;
-  pipe_params.tb_rate = 0;
-  pipe_params.tb_size = 0;
+  params.n_pipe_profiles = 1;
+
+  // set the same size for all queues
   for (i = 0; i < RTE_SCHED_TRAFFIC_CLASSES_PER_PIPE; i++) {
     params.qsize[i] = 128;
   }
+
+  // assotiate each queue with its own traffic class
+  // order queues in accordance to their priorities
+  // the lower priority, the more packets processed
+  sort_by_ascending_priority(ifqueue);
+
+  // set up phony weights for queues within each traffic class
+  for (i = 0; i < RTE_SCHED_QUEUES_PER_PIPE; i++) {
+    pipe_params.wrr_weights[i] = 1; // must be positive
+  }
+
+  // enforcing upper limits for each traffic class queues
+  //  bursts are used to set up the overall port policing
+  burst_sum = rate_sum = 0;
   for (i = 0; i < ifqueue->nqueue; i++) {
-    params.rate += ifqueue->queues[i]->peak_information_rate;
-    subport_params.tb_rate += ifqueue->queues[i]->peak_information_rate;
-    subport_params.tb_size += ifqueue->queues[i]->committed_burst_size;
-    pipe_params.tb_rate += ifqueue->queues[i]->peak_information_rate;
-    pipe_params.tb_size += ifqueue->queues[i]->committed_burst_size;
-    pipe_params.wrr_weights[i] = ifqueue->queues[i]->priority;
+    uint32_t burst, rate;
+    if (ifqueue->queues[i]->peak_information_rate <= UINT32_MAX) {
+      rate = (uint32_t)ifqueue->queues[i]->peak_information_rate;
+    } else return LAGOPUS_RESULT_OUT_OF_RANGE;
+
+    if (rate_sum > UINT32_MAX - rate) {
+      rate_sum = UINT32_MAX;
+    } else rate_sum += rate;
+
+    subport_params.tc_rate[i] = rate;
+    pipe_params.tc_rate[i] = rate;
+
+    if (ifqueue->queues[i]->committed_burst_size <= UINT32_MAX) {
+      burst = (uint32_t)ifqueue->queues[i]->committed_burst_size;
+    } else return LAGOPUS_RESULT_OUT_OF_RANGE;
+
+    if (burst_sum > UINT32_MAX - burst) {
+      burst_sum = UINT32_MAX;
+    } else burst_sum += burst;
   }
-  for (; i < RTE_SCHED_QUEUES_PER_PIPE; i++) {
-    pipe_params.wrr_weights[i] = 1;
+
+  for (; i < RTE_SCHED_TRAFFIC_CLASSES_PER_PIPE; i++) {
+    subport_params.tc_rate[i] = 1; // must be positive
+    pipe_params.tc_rate[i] = 1; // must be positive
   }
-  for (i = 0; i < RTE_SCHED_TRAFFIC_CLASSES_PER_PIPE; i++) {
-    subport_params.tc_rate[i] = subport_params.tb_rate;
-    pipe_params.tc_rate[i] = pipe_params.tb_rate;
-  }
+
+  // adjusting parameters of the token buckets
+  //  to pass the traffic at all levels of the scheduler
+  params.rate = rate_sum;
+
+  subport_params.tc_period = 100;
+  subport_params.tb_rate = rate_sum;
+  subport_params.tb_size = burst_sum;
+
   pipe_params.tc_period = 100;
-  params.n_pipe_profiles = 1;
+  pipe_params.tb_rate = rate_sum;
+  pipe_params.tb_size = burst_sum;
 
 #ifdef RTE_SCHED_RED
   for (i = 0; i < RTE_SCHED_TRAFFIC_CLASSES_PER_PIPE; i++) {
@@ -129,23 +208,28 @@ dpdk_queue_configure(struct interface *ifp, struct dp_ifqueue *ifqueue) {
   }
 #endif /* RTE_SCHED_RED */
 
-  new_sched = rte_sched_port_config(&params);
-  if (new_sched == NULL) {
-    lagopus_msg_error("rte_sched_port_config got error\n");
+  // resetting the port scheduler
+  if ((new_sched = rte_sched_port_config(&params)) == NULL) {
+    lagopus_msg_error("rte_sched_port_config got error");
+  } else
+  if ((rte_err = rte_sched_subport_config(new_sched, 0, &subport_params)) != 0) {
+    lagopus_msg_error("rte_sched_subport_config got error: %d\n", rte_err);
+  } else
+  if ((rte_err = rte_sched_pipe_config(new_sched, 0, 0, 0)) != 0) {
+    lagopus_msg_error("rte_sched_pipe_config got error: %d\n", rte_err);
+  } else {
+    // everything worked as expected
+    //  swapping the old scheduler with the new one
+    if (!ifp->sched_port) rte_sched_port_free(ifp->sched_port);
+    ifp->sched_port = new_sched;
+    return LAGOPUS_RESULT_OK;
   }
-  if (rte_sched_subport_config(new_sched, 0, &subport_params) != 0) {
-    lagopus_msg_error("rte_sched_subport_config got error\n");
-  }
-  if (rte_sched_pipe_config(new_sched, 0, 0, 0) != 0) {
-    lagopus_msg_error("rte_sched_pipe_config got error\n");
-  }
-  old_sched = ifp->sched_port;
-  ifp->sched_port = new_sched;
-  if (old_sched != NULL) {
-    rte_sched_port_free(old_sched);
-  }
-  return LAGOPUS_RESULT_OK;
+
+  // scheduler initialization failed
+  if (!new_sched) rte_sched_port_free(new_sched);
+  return LAGOPUS_RESULT_ANY_FAILURES;
 }
+
 
 void
 dpdk_queue_unconfigure(struct interface *ifp) {

--- a/src/dataplane/mgr/dp_apis.c
+++ b/src/dataplane/mgr/dp_apis.c
@@ -1318,12 +1318,22 @@ dp_queue_create(const char *name,
     rv = LAGOPUS_RESULT_ALREADY_EXISTS;
     goto out;
   }
+
+// TODO: Allow queeus with the same ids
+// Switch should permit multiple queues with the same id
+//  while each of these queues belongs to a its own port.
+// We should either enforce unique pairs <port, switch>,
+//  or disable these checks in datastore at all --
+//  inconsistent configurations will fail on init.
+
+/*
   id = queue_info->id;
   rv = lagopus_hashmap_find(&queueid_hashmap, (void *)id, (void **)&queue);
   if (rv == LAGOPUS_RESULT_OK) {
     rv = LAGOPUS_RESULT_ALREADY_EXISTS;
     goto out;
   }
+*/
   queue = calloc(1, sizeof(datastore_queue_info_t));
   if (queue == NULL) {
     rv = LAGOPUS_RESULT_NO_MEMORY;
@@ -1336,9 +1346,11 @@ dp_queue_create(const char *name,
     if (rv != LAGOPUS_RESULT_OK) {
       goto out;
     }
+/*
     id = queue_info->id;
     rv = lagopus_hashmap_add(&queueid_hashmap, (void *)id,
                              (void **)&queue, false);
+*/
   }
 out:
   return rv;

--- a/src/dataplane/mgr/queue.c
+++ b/src/dataplane/mgr/queue.c
@@ -20,6 +20,83 @@
  */
 
 #include "lagopus/ofp_dp_apis.h"
+#include "lagopus/dp_apis.h"
+
+#include "lagopus/interface.h"
+#include "lagopus/port.h"
+
+
+static lagopus_result_t
+append_queue_config(struct interface *ifp, uint32_t qidx,
+    struct packet_queue_list *packet_queue_list) {
+
+  struct packet_queue *queue;
+  struct queue_property *property;
+  uint64_t queue_rate_in_bps;
+  uint32_t port_speed;
+
+  queue = calloc(1, sizeof(struct packet_queue));
+  if (!queue) return LAGOPUS_RESULT_NO_MEMORY;
+
+  TAILQ_INSERT_TAIL(packet_queue_list, queue, entry);
+  queue->ofp.len = sizeof(struct ofp_packet_queue);
+  queue->ofp.queue_id = ifp->ifqueue.queues[qidx]->id;
+  queue->ofp.port = ifp->port->ofp_port.port_no;
+  TAILQ_INIT(&queue->queue_property_list);
+
+  port_speed = ifp->port->ofp_port.curr_speed;
+  if (!port_speed) port_speed = ifp->port->ofp_port.max_speed;
+  if (!port_speed) return LAGOPUS_RESULT_OK;
+
+  property = calloc(1, sizeof(struct queue_property));
+  if (!property) return LAGOPUS_RESULT_NO_MEMORY;
+
+  TAILQ_INSERT_TAIL(&queue->queue_property_list, property, entry);
+  // rate is measured in 1/10 of a percent of a current port bandwidth
+  queue_rate_in_bps = ifp->ifqueue.queues[qidx]->committed_information_rate << 3;
+  property->rate = (uint16_t)(queue_rate_in_bps / port_speed);
+  property->ofp.len = sizeof(struct ofp_queue_prop_min_rate);
+  property->ofp.property = OFPQT_MIN_RATE;
+  queue->ofp.len += property->ofp.len;
+
+  property = calloc(1, sizeof(struct queue_property));
+  if (!property) return LAGOPUS_RESULT_NO_MEMORY;
+
+  TAILQ_INSERT_TAIL(&queue->queue_property_list, property, entry);
+  // rate is measured in 1/10 of a percent of a current port bandwidth
+  queue_rate_in_bps = ifp->ifqueue.queues[qidx]->peak_information_rate << 3;
+  property->rate = (uint16_t)(queue_rate_in_bps / port_speed);
+  property->ofp.len = sizeof(struct ofp_queue_prop_max_rate);
+  property->ofp.property = OFPQT_MAX_RATE;
+  queue->ofp.len += property->ofp.len;
+
+  return LAGOPUS_RESULT_OK;
+}
+
+
+static lagopus_result_t
+append_ifp_queue_config(struct interface *ifp, struct packet_queue_list *packet_queue_list) {
+  for(uint32_t i = 0; i < (uint32_t)ifp->ifqueue.nqueue; ++i) {
+    lagopus_result_t rv = append_queue_config(ifp, i, packet_queue_list);
+    if (rv != LAGOPUS_RESULT_OK) return rv;
+  }
+  return LAGOPUS_RESULT_OK;
+}
+
+
+static bool
+iterate_port_queue_config(void *key, void *port,
+     lagopus_hashentry_t he, void *packet_queue_list) {
+
+  lagopus_result_t rv;
+  (void) key;
+  (void) he;
+
+  // skip unsupported ports and continue iteration
+  if (!port || !((struct port*)port)->interface) return true;
+  rv = append_ifp_queue_config(((struct port*)port)->interface, packet_queue_list);
+  return rv == LAGOPUS_RESULT_OK;
+}
 
 
 /*
@@ -30,11 +107,114 @@ ofp_packet_queue_get(uint64_t dpid,
                      struct ofp_queue_get_config_request *queue_request,
                      struct packet_queue_list *packet_queue_list,
                      struct ofp_error *error) {
-  (void) dpid;
-  (void) queue_request;
-  (void) packet_queue_list;
+  struct bridge *bridge;
+  lagopus_result_t rv;
   (void) error;
+
+  bridge = dp_bridge_lookup_by_dpid(dpid);
+  if (!bridge) return LAGOPUS_RESULT_NOT_FOUND;
+  if (!queue_request) return LAGOPUS_RESULT_INVALID_ARGS;
+
+  if (queue_request->port == OFPP_ANY) {
+    rv = lagopus_hashmap_iterate(&bridge->ports, iterate_port_queue_config, packet_queue_list);
+  } else {
+    struct port *port = port_lookup(&bridge->ports, queue_request->port);
+    if (port && port->interface) {
+      rv = append_ifp_queue_config(port->interface, packet_queue_list);
+    } else rv = LAGOPUS_RESULT_NOT_FOUND;
+  }
+
+  return rv;
+}
+
+
+static lagopus_result_t
+append_queue_stats(struct interface *ifp, uint32_t qidx,
+   struct queue_stats_list *queue_stats_list) {
+  
+  struct queue_stats *stats;
+  struct timespec *created, now;
+
+#ifdef HAVE_DPDK
+  struct rte_sched_queue_stats *curr_stats, update;
+  uint16_t queue_len;
+
+  uint32_t rte_queue_id = qidx * RTE_SCHED_TRAFFIC_CLASSES_PER_PIPE;
+  if (rte_sched_queue_read_stats(ifp->sched_port, rte_queue_id, &update, &queue_len) != 0) {
+    return LAGOPUS_RESULT_NOT_FOUND;
+  }  
+
+  curr_stats = &ifp->ifqueue.stats[qidx];
+  curr_stats->n_bytes += update.n_bytes;
+  curr_stats->n_pkts += update.n_pkts;
+  curr_stats->n_bytes_dropped += update.n_bytes_dropped;
+  curr_stats->n_pkts_dropped += update.n_pkts_dropped;
+#endif // HAVE_DPDK
+
+  stats = calloc(1, sizeof(struct queue_stats));
+  if (!stats) return LAGOPUS_RESULT_NO_MEMORY;
+  TAILQ_INSERT_TAIL(queue_stats_list, stats, entry);
+
+  stats->ofp.port_no = ifp->port->ofp_port.port_no;
+  stats->ofp.queue_id = ifp->ifqueue.queues[qidx]->id;
+
+#ifdef HAVE_DPDK
+  stats->ofp.tx_bytes = curr_stats->n_bytes;
+  stats->ofp.tx_packets = curr_stats->n_pkts;
+  stats->ofp.tx_errors = curr_stats->n_pkts_dropped;
+#endif // HAVE_DPDK
+
+  created = &ifp->port->create_time;
+  now = get_current_time();
+  stats->ofp.duration_sec = (uint32_t)(now.tv_sec - created->tv_sec);
+  stats->ofp.duration_nsec = (uint32_t)(now.tv_nsec - created->tv_nsec);
   return LAGOPUS_RESULT_OK;
+}
+
+
+struct queue_stats_context {
+  struct queue_stats_list *queue_stats_list;
+  uint32_t ofp_queue_id;
+};
+
+
+static lagopus_result_t
+append_ifp_queue_stats(struct interface *ifp, struct queue_stats_context *queue_stats_context) {
+  if (!ifp->sched_port) return LAGOPUS_RESULT_NOT_FOUND;
+
+  if (queue_stats_context->ofp_queue_id == OFPQ_ALL) {
+    for(uint32_t i = 0; i < (uint32_t)ifp->ifqueue.nqueue; ++i) {
+      lagopus_result_t rv = append_queue_stats(ifp, i, queue_stats_context->queue_stats_list);
+      if (rv != LAGOPUS_RESULT_OK) return rv;
+    }
+    return LAGOPUS_RESULT_OK;
+  }
+
+  for(uint32_t i = 0; i < (uint32_t)ifp->ifqueue.nqueue; ++i) {
+    if (queue_stats_context->ofp_queue_id == ifp->ifqueue.queues[i]->id) {
+      return append_queue_stats(ifp, i, queue_stats_context->queue_stats_list);
+    }
+  }
+  return LAGOPUS_RESULT_NOT_FOUND;
+}
+
+
+static bool
+iterate_port_queue_stats(void *key, void *port,
+     lagopus_hashentry_t he, void *queue_stats_context) {
+  
+  (void) key;
+  (void) he;
+
+  if (!port || !((struct port*)port)->interface) return true;
+  switch (append_ifp_queue_stats(((struct port*)port)->interface, queue_stats_context)) {
+    // continue iteration when returned status is
+    case LAGOPUS_RESULT_OK: break;
+    case LAGOPUS_RESULT_NOT_FOUND: break;
+    // skip iteration otherwise
+    default: return false;
+  }
+  return true;
 }
 
 
@@ -46,9 +226,27 @@ ofp_queue_stats_request_get(uint64_t dpid,
                             struct ofp_queue_stats_request *queue_stats_request,
                             struct queue_stats_list *queue_stats_list,
                             struct ofp_error *error) {
-  (void) dpid;
-  (void) queue_stats_request;
-  (void) queue_stats_list;
+
+  struct queue_stats_context queue_stats_context;
+  struct bridge *bridge;
+  lagopus_result_t rv;
   (void) error;
-  return LAGOPUS_RESULT_OK;
+
+  bridge = dp_bridge_lookup_by_dpid(dpid);
+  if (!bridge) return LAGOPUS_RESULT_NOT_FOUND;
+  if (!queue_stats_request) return LAGOPUS_RESULT_INVALID_ARGS; 
+
+  // prepare request context to search queues on multiple ports
+  queue_stats_context.queue_stats_list = queue_stats_list;
+  queue_stats_context.ofp_queue_id = queue_stats_request->queue_id;
+
+  if (queue_stats_request->port_no == OFPP_ANY) {
+    rv = lagopus_hashmap_iterate(&bridge->ports, iterate_port_queue_stats, &queue_stats_context);
+  } else {
+    struct port *port = port_lookup(&bridge->ports, queue_stats_request->port_no);
+    if (!port || !port->interface) return LAGOPUS_RESULT_NOT_FOUND;
+    rv = append_ifp_queue_stats(port->interface, &queue_stats_context);
+  }
+
+  return rv;
 }

--- a/src/include/lagopus/interface.h
+++ b/src/include/lagopus/interface.h
@@ -58,6 +58,7 @@ typedef datastore_queue_info_t dp_queue_info_t;
 #endif /* HYBRID */
 #define INTERFACE_NAME_DELIMITER '+'  /* used by tap io. */
 
+
 /**
  * @brief Output queues associated with interface.
  */
@@ -65,6 +66,7 @@ struct dp_ifqueue {
   int nqueue;
   dp_queue_info_t *queues[DP_MAX_QUEUES];
 #ifdef HAVE_DPDK
+  struct rte_sched_queue_stats stats[RTE_SCHED_QUEUES_PER_TRAFFIC_CLASS];
   struct rte_meter_trtcm meters[RTE_SCHED_QUEUES_PER_TRAFFIC_CLASS];
 #endif /* HAVE_DPDK */
 };


### PR DESCRIPTION
- Remove the restriction on queue ids
    - now it is possible to create queues with the same id at different ports;
- Fix qos scheduler initialization:
    - add a more rigorous checks for shaping parameters;
    - rollback to previos scheduler config on errors;
    - map queues to DPDK scheduler to enable PQ;
- Enable queue scheduling for each transmitted packet;
- Add support for queue_config and queue_stats openflow requests;
- Change DPDK build options to enable qos scheduler statistics.