### PR TITLE
Fix the return value of rawsock OS_M_ADJ

### DIFF
--- a/src/dataplane/sock/pktbuf.h
+++ b/src/dataplane/sock/pktbuf.h
@@ -47,7 +47,7 @@ struct sock_buf {
 #define OS_M_PKTLEN(m)    ((m)->len)
 #define OS_M_PREPEND(m,n) ((m)->data -= (n), (m)->len += (n), (m)->data)
 #define OS_M_APPEND(m,n)  ((m)->len += (n), (m)->data + (m)->len - (n))
-#define OS_M_ADJ(m,n)     ((m)->data += (n), (m)->len -= (n))
+#define OS_M_ADJ(m,n)     ((m)->data += (n), (m)->len -= (n), (m)->data)
 #define OS_M_TRIM(m,n)    ((m)->len -= (n))
 #define OS_M_FREE(m)      sock_m_free(m)
 #define OS_MTOD(m,type)   ((type)(m)->data)


### PR DESCRIPTION
In execute_action_decap function, OS_M_ADJ must returns new protocol header pointer.
It has returned incorrect value in rawsock mode.
Fixed it.