### PR TITLE
Accept OFPT_SET_CONFIG with miss_send_len=0

### DIFF
--- a/src/dataplane/mgr/bridge.c
+++ b/src/dataplane/mgr/bridge.c
@@ -484,13 +484,6 @@ ofp_switch_config_set(uint64_t dpid,
                      error->type, error->code);
     return LAGOPUS_RESULT_OFP_ERROR;
   }
-  if (switch_config->miss_send_len < 64) {
-    error->type = OFPET_SWITCH_CONFIG_FAILED;
-    error->code = OFPSCFC_BAD_LEN;
-    lagopus_msg_info("switch config: %d: too short length (%d:%d)\n",
-                     switch_config->miss_send_len, error->type, error->code);
-    return LAGOPUS_RESULT_OFP_ERROR;
-  }
   bridge->switch_config = *switch_config;
 
   return LAGOPUS_RESULT_OK;


### PR DESCRIPTION
Lagopus refuses OFPT_SET_CONFIG with miss_send_len == 0.
According to the OpenFlow Switch Spec., it should be accepted.

> If this field equals 0, the switch must
send zero bytes of the packet in the ofp_packet_in message.