### PR TITLE
 Fix segmentation fault for flow modify

### DIFF
--- a/src/dataplane/mgr/flowdb.c
+++ b/src/dataplane/mgr/flowdb.c
@@ -1176,6 +1176,9 @@ flow_modify_sub(struct bridge *bridge,
   if (flow == NULL) {
     goto out;
   }
+  flow->bridge = bridge;
+  flow->table_id = flow_mod->table_id;
+
   ret = flow_pre_requisite_check(flow, &flow->match_list, error);
   if (ret != LAGOPUS_RESULT_OK) {
     flow_free(flow);


### PR DESCRIPTION
flow_modify_sub() does not set flow->bridge and flow->table_id.
It causes segmentation faults.